### PR TITLE
Extract ValueAccess Trait

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -518,7 +518,7 @@ where
     let backslash = _mm256_set1_epi8(b'\\' as i8);
     while string.len() - idx >= 32 {
         // Load 32 bytes of data;
-        let data: __m256i = _mm256_loadu_si256(string.as_ptr().add(idx) as *const __m256i);
+        let data: __m256i = _mm256_loadu_si256(string.as_ptr().add(idx).cast::<__m256i>());
         // Test the data against being backslash and quote.
         let bs_or_quote = _mm256_or_si256(
             _mm256_cmpeq_epi8(data, backslash),
@@ -581,7 +581,7 @@ where
     let backslash = _mm_set1_epi8(b'\\' as i8);
     while string.len() - idx > 16 {
         // Load 16 bytes of data;
-        let data: __m128i = _mm_loadu_si128(string.as_ptr().add(idx) as *const __m128i);
+        let data: __m128i = _mm_loadu_si128(string.as_ptr().add(idx).cast::<__m128i>());
         // Test the data against being backslash and quote.
         let bs_or_quote =
             _mm_or_si128(_mm_cmpeq_epi8(data, backslash), _mm_cmpeq_epi8(data, quote));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ mod array;
 pub mod generator;
 mod node;
 mod object;
+mod option;
+/// Prelude for traits
+pub mod prelude;
 
 pub use array::Array;
 pub use node::StaticNode;
@@ -151,40 +154,23 @@ pub trait Builder<'input>:
     fn null() -> Self;
 }
 
-/// The `Value` exposes common interface for values, this allows using both
-/// `BorrowedValue` and `OwnedValue` nearly interchangable
-pub trait Value:
-    Sized
-    + Index<usize>
-    + PartialEq<i8>
-    + PartialEq<i16>
-    + PartialEq<i32>
-    + PartialEq<i64>
-    + PartialEq<i128>
-    + PartialEq<u8>
-    + PartialEq<u16>
-    + PartialEq<u32>
-    + PartialEq<u64>
-    + PartialEq<u128>
-    + PartialEq<f32>
-    + PartialEq<f64>
-    + PartialEq<String>
-    + PartialEq<bool>
-    + PartialEq<()>
-{
+/// Trait to allow accessing data inside a Value
+pub trait ValueAccess: Sized {
+    /// The target for nested lookups
+    type Target: ValueAccess;
     /// The type for Objects
     type Key: Hash + Eq;
     /// The array structure
-    type Array: Array<Element = Self>;
+    type Array: Array<Element = Self::Target>;
     /// The object structure
-    type Object: Object<Key = Self::Key, Element = Self>;
+    type Object: Object<Key = Self::Key, Element = Self::Target>;
 
     /// Gets a ref to a value based on a key, returns `None` if the
     /// current Value isn't an Object or doesn't contain the key
     /// it was asked for.
     #[inline]
     #[must_use]
-    fn get<Q: ?Sized>(&self, k: &Q) -> Option<&Self>
+    fn get<Q: ?Sized>(&self, k: &Q) -> Option<&Self::Target>
     where
         Self::Key: Borrow<Q> + Hash + Eq,
         Q: Hash + Eq + Ord,
@@ -209,10 +195,348 @@ pub trait Value:
     /// it was asked for.
     #[inline]
     #[must_use]
-    fn get_idx(&self, i: usize) -> Option<&Self> {
+    fn get_idx(&self, i: usize) -> Option<&Self::Target> {
         self.as_array().and_then(|a| a.get(i))
     }
 
+    /// Tries to get an element of an object as a bool
+    #[inline]
+    #[must_use]
+    fn get_bool<Q: ?Sized>(&self, k: &Q) -> Option<bool>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_bool)
+    }
+
+    /// Tries to represent the value as a bool
+    #[must_use]
+    fn as_bool(&self) -> Option<bool>;
+
+    /// Tries to represent the value as an i128
+    #[inline]
+    #[must_use]
+    fn as_i128(&self) -> Option<i128> {
+        self.as_i64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a i128
+    #[inline]
+    #[must_use]
+    fn get_i128<Q: ?Sized>(&self, k: &Q) -> Option<i128>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_i128)
+    }
+
+    /// Tries to represent the value as an i64
+    #[must_use]
+    fn as_i64(&self) -> Option<i64>;
+    /// Tries to get an element of an object as a i64
+
+    #[inline]
+    #[must_use]
+    fn get_i64<Q: ?Sized>(&self, k: &Q) -> Option<i64>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_i64)
+    }
+
+    /// Tries to represent the value as an i32
+    #[inline]
+    #[must_use]
+    fn as_i32(&self) -> Option<i32> {
+        self.as_i64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a i32
+    #[inline]
+    #[must_use]
+    fn get_i32<Q: ?Sized>(&self, k: &Q) -> Option<i32>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_i32)
+    }
+
+    /// Tries to represent the value as an i16
+    #[inline]
+    #[must_use]
+    fn as_i16(&self) -> Option<i16> {
+        self.as_i64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a i16
+    #[inline]
+    #[must_use]
+    fn get_i16<Q: ?Sized>(&self, k: &Q) -> Option<i16>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_i16)
+    }
+
+    /// Tries to represent the value as an i8
+    #[inline]
+    #[must_use]
+    fn as_i8(&self) -> Option<i8> {
+        self.as_i64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a i8
+    #[inline]
+    #[must_use]
+    fn get_i8<Q: ?Sized>(&self, k: &Q) -> Option<i8>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_i8)
+    }
+
+    /// Tries to represent the value as an u128
+    #[inline]
+    #[must_use]
+    fn as_u128(&self) -> Option<u128> {
+        self.as_u64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a u128
+    #[inline]
+    #[must_use]
+    fn get_u128<Q: ?Sized>(&self, k: &Q) -> Option<u128>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_u128)
+    }
+
+    /// Tries to represent the value as an u64
+    #[must_use]
+    fn as_u64(&self) -> Option<u64>;
+
+    /// Tries to get an element of an object as a u64
+    #[inline]
+    #[must_use]
+    fn get_u64<Q: ?Sized>(&self, k: &Q) -> Option<u64>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_u64)
+    }
+
+    /// Tries to represent the value as an usize
+    #[inline]
+    #[must_use]
+    fn as_usize(&self) -> Option<usize> {
+        self.as_u64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a usize
+    #[inline]
+    #[must_use]
+    fn get_usize<Q: ?Sized>(&self, k: &Q) -> Option<usize>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_usize)
+    }
+
+    /// Tries to represent the value as an u32
+    #[inline]
+    #[must_use]
+    fn as_u32(&self) -> Option<u32> {
+        self.as_u64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a u32
+    #[inline]
+    #[must_use]
+    fn get_u32<Q: ?Sized>(&self, k: &Q) -> Option<u32>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_u32)
+    }
+
+    /// Tries to represent the value as an u16
+    #[inline]
+    #[must_use]
+    fn as_u16(&self) -> Option<u16> {
+        self.as_u64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a u16
+    #[inline]
+    #[must_use]
+    fn get_u16<Q: ?Sized>(&self, k: &Q) -> Option<u16>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_u16)
+    }
+
+    /// Tries to represent the value as an u8
+    #[inline]
+    #[must_use]
+    fn as_u8(&self) -> Option<u8> {
+        self.as_u64().and_then(|u| u.try_into().ok())
+    }
+
+    /// Tries to get an element of an object as a u8
+    #[inline]
+    #[must_use]
+    fn get_u8<Q: ?Sized>(&self, k: &Q) -> Option<u8>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_u8)
+    }
+
+    /// Tries to represent the value as a f64
+    #[must_use]
+    fn as_f64(&self) -> Option<f64>;
+
+    /// Tries to get an element of an object as a f64
+    #[inline]
+    #[must_use]
+    fn get_f64<Q: ?Sized>(&self, k: &Q) -> Option<f64>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_f64)
+    }
+
+    /// Casts the current value to a f64 if possible, this will turn integer
+    /// values into floats.
+    #[must_use]
+    #[inline]
+    #[allow(clippy::cast_precision_loss, clippy::option_if_let_else)]
+    fn cast_f64(&self) -> Option<f64> {
+        if let Some(f) = self.as_f64() {
+            Some(f)
+        } else if let Some(u) = self.as_u128() {
+            Some(u as f64)
+        } else if let Some(i) = self.as_i128() {
+            Some(i as f64)
+        } else {
+            None
+        }
+    }
+
+    /// Tries to represent the value as a f32
+    #[allow(clippy::cast_possible_truncation)]
+    #[inline]
+    #[must_use]
+    fn as_f32(&self) -> Option<f32> {
+        self.as_f64().and_then(|u| {
+            if u <= f64::from(std::f32::MAX) && u >= f64::from(std::f32::MIN) {
+                // Since we check above
+                Some(u as f32)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Tries to get an element of an object as a f32
+    #[inline]
+    #[must_use]
+    fn get_f32<Q: ?Sized>(&self, k: &Q) -> Option<f32>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_f32)
+    }
+
+    /// Tries to represent the value as a &str
+    #[must_use]
+    fn as_str(&self) -> Option<&str>;
+
+    /// Tries to get an element of an object as a str
+    #[inline]
+    #[must_use]
+    fn get_str<Q: ?Sized>(&self, k: &Q) -> Option<&str>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_str)
+    }
+
+    /// Tries to represent the value as an array and returns a refference to it
+    #[must_use]
+    fn as_array(&self) -> Option<&Self::Array>;
+
+    /// Tries to get an element of an object as a array
+    #[inline]
+    #[must_use]
+    fn get_array<Q: ?Sized>(
+        &self,
+        k: &Q,
+    ) -> Option<&<<Self as ValueAccess>::Target as ValueAccess>::Array>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_array)
+    }
+
+    /// Tries to represent the value as an object and returns a refference to it
+    #[must_use]
+    fn as_object(&self) -> Option<&Self::Object>;
+
+    /// Tries to get an element of an object as a object
+    #[inline]
+    #[must_use]
+    fn get_object<Q: ?Sized>(
+        &self,
+        k: &Q,
+    ) -> Option<&<<Self as ValueAccess>::Target as ValueAccess>::Object>
+    where
+        Self::Key: Borrow<Q> + Hash + Eq,
+        Q: Hash + Eq + Ord,
+    {
+        self.get(k).and_then(ValueAccess::as_object)
+    }
+}
+/// The `Value` exposes common interface for values, this allows using both
+/// `BorrowedValue` and `OwnedValue` nearly interchangable
+pub trait Value:
+    Sized
+    + Index<usize>
+    + PartialEq<i8>
+    + PartialEq<i16>
+    + PartialEq<i32>
+    + PartialEq<i64>
+    + PartialEq<i128>
+    + PartialEq<u8>
+    + PartialEq<u16>
+    + PartialEq<u32>
+    + PartialEq<u64>
+    + PartialEq<u128>
+    + PartialEq<f32>
+    + PartialEq<f64>
+    + PartialEq<String>
+    + PartialEq<bool>
+    + PartialEq<()>
+    + ValueAccess
+{
     /// Returns the type of the current Valye
     #[must_use]
     fn value_type(&self) -> ValueType;
@@ -242,44 +566,11 @@ pub trait Value:
         self.is_float() || self.is_integer()
     }
 
-    /// Tries to represent the value as a bool
-    #[must_use]
-    fn as_bool(&self) -> Option<bool>;
     /// returns true if the current value a bool
-
     #[inline]
     #[must_use]
     fn is_bool(&self) -> bool {
         self.as_bool().is_some()
-    }
-
-    /// Tries to get an element of an object as a bool
-    #[inline]
-    #[must_use]
-    fn get_bool<Q: ?Sized>(&self, k: &Q) -> Option<bool>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_bool)
-    }
-
-    /// Tries to represent the value as an i128
-    #[inline]
-    #[must_use]
-    fn as_i128(&self) -> Option<i128> {
-        self.as_i64().and_then(|u| u.try_into().ok())
-    }
-
-    /// Tries to get an element of an object as a i128
-    #[inline]
-    #[must_use]
-    fn get_i128<Q: ?Sized>(&self, k: &Q) -> Option<i128>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_i128)
     }
 
     /// returns true if the current value can be represented as a i128
@@ -289,33 +580,11 @@ pub trait Value:
         self.as_i128().is_some()
     }
 
-    /// Tries to represent the value as an i64
-    #[must_use]
-    fn as_i64(&self) -> Option<i64>;
-
     /// returns true if the current value can be represented as a i64
     #[inline]
     #[must_use]
     fn is_i64(&self) -> bool {
         self.as_i64().is_some()
-    }
-
-    /// Tries to get an element of an object as a i64
-    #[inline]
-    #[must_use]
-    fn get_i64<Q: ?Sized>(&self, k: &Q) -> Option<i64>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_i64)
-    }
-
-    /// Tries to represent the value as an i32
-    #[inline]
-    #[must_use]
-    fn as_i32(&self) -> Option<i32> {
-        self.as_i64().and_then(|u| u.try_into().ok())
     }
 
     /// returns true if the current value can be represented as a i32
@@ -325,47 +594,11 @@ pub trait Value:
         self.as_i32().is_some()
     }
 
-    /// Tries to get an element of an object as a i32
-    #[inline]
-    #[must_use]
-    fn get_i32<Q: ?Sized>(&self, k: &Q) -> Option<i32>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_i32)
-    }
-
-    /// Tries to represent the value as an i16
-    #[inline]
-    #[must_use]
-    fn as_i16(&self) -> Option<i16> {
-        self.as_i64().and_then(|u| u.try_into().ok())
-    }
-
     /// returns true if the current value can be represented as a i16
     #[inline]
     #[must_use]
     fn is_i16(&self) -> bool {
         self.as_i16().is_some()
-    }
-
-    /// Tries to get an element of an object as a i16
-    #[inline]
-    #[must_use]
-    fn get_i16<Q: ?Sized>(&self, k: &Q) -> Option<i16>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_i16)
-    }
-
-    /// Tries to represent the value as an i8
-    #[inline]
-    #[must_use]
-    fn as_i8(&self) -> Option<i8> {
-        self.as_i64().and_then(|u| u.try_into().ok())
     }
 
     /// returns true if the current value can be represented as a i8
@@ -375,23 +608,6 @@ pub trait Value:
         self.as_i8().is_some()
     }
 
-    /// Tries to get an element of an object as a i8
-    #[inline]
-    #[must_use]
-    fn get_i8<Q: ?Sized>(&self, k: &Q) -> Option<i8>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_i8)
-    }
-
-    /// Tries to represent the value as an u128
-    #[inline]
-    #[must_use]
-    fn as_u128(&self) -> Option<u128> {
-        self.as_u64().and_then(|u| u.try_into().ok())
-    }
     /// returns true if the current value can be represented as a u128
     #[inline]
     #[must_use]
@@ -399,44 +615,11 @@ pub trait Value:
         self.as_u128().is_some()
     }
 
-    /// Tries to get an element of an object as a u128
-    #[inline]
-    #[must_use]
-    fn get_u128<Q: ?Sized>(&self, k: &Q) -> Option<u128>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_u128)
-    }
-
-    /// Tries to represent the value as an u64
-    #[must_use]
-    fn as_u64(&self) -> Option<u64>;
-
     /// returns true if the current value can be represented as a u64
     #[inline]
     #[must_use]
     fn is_u64(&self) -> bool {
         self.as_u64().is_some()
-    }
-
-    /// Tries to get an element of an object as a u64
-    #[inline]
-    #[must_use]
-    fn get_u64<Q: ?Sized>(&self, k: &Q) -> Option<u64>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_u64)
-    }
-
-    /// Tries to represent the value as an usize
-    #[inline]
-    #[must_use]
-    fn as_usize(&self) -> Option<usize> {
-        self.as_u64().and_then(|u| u.try_into().ok())
     }
 
     /// returns true if the current value can be represented as a usize
@@ -446,47 +629,11 @@ pub trait Value:
         self.as_usize().is_some()
     }
 
-    /// Tries to get an element of an object as a usize
-    #[inline]
-    #[must_use]
-    fn get_usize<Q: ?Sized>(&self, k: &Q) -> Option<usize>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_usize)
-    }
-
-    /// Tries to represent the value as an u32
-    #[inline]
-    #[must_use]
-    fn as_u32(&self) -> Option<u32> {
-        self.as_u64().and_then(|u| u.try_into().ok())
-    }
-
     /// returns true if the current value can be represented as a u32
     #[inline]
     #[must_use]
     fn is_u32(&self) -> bool {
         self.as_u32().is_some()
-    }
-
-    /// Tries to get an element of an object as a u32
-    #[inline]
-    #[must_use]
-    fn get_u32<Q: ?Sized>(&self, k: &Q) -> Option<u32>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_u32)
-    }
-
-    /// Tries to represent the value as an u16
-    #[inline]
-    #[must_use]
-    fn as_u16(&self) -> Option<u16> {
-        self.as_u64().and_then(|u| u.try_into().ok())
     }
 
     /// returns true if the current value can be represented as a u16
@@ -496,45 +643,12 @@ pub trait Value:
         self.as_u16().is_some()
     }
 
-    /// Tries to get an element of an object as a u16
-    #[inline]
-    #[must_use]
-    fn get_u16<Q: ?Sized>(&self, k: &Q) -> Option<u16>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_u16)
-    }
-
-    /// Tries to represent the value as an u8
-    #[inline]
-    #[must_use]
-    fn as_u8(&self) -> Option<u8> {
-        self.as_u64().and_then(|u| u.try_into().ok())
-    }
-
     /// returns true if the current value can be represented as a u8
     #[inline]
     #[must_use]
     fn is_u8(&self) -> bool {
         self.as_u8().is_some()
     }
-
-    /// Tries to get an element of an object as a u8
-    #[inline]
-    #[must_use]
-    fn get_u8<Q: ?Sized>(&self, k: &Q) -> Option<u8>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_u8)
-    }
-
-    /// Tries to represent the value as a f64
-    #[must_use]
-    fn as_f64(&self) -> Option<f64>;
 
     /// returns true if the current value can be represented as a f64
     #[inline]
@@ -543,53 +657,11 @@ pub trait Value:
         self.as_f64().is_some()
     }
 
-    /// Tries to get an element of an object as a f64
-    #[inline]
-    #[must_use]
-    fn get_f64<Q: ?Sized>(&self, k: &Q) -> Option<f64>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_f64)
-    }
-
-    /// Casts the current value to a f64 if possible, this will turn integer
-    /// values into floats.
-    #[must_use]
-    #[inline]
-    #[allow(clippy::cast_precision_loss, clippy::option_if_let_else)]
-    fn cast_f64(&self) -> Option<f64> {
-        if let Some(f) = self.as_f64() {
-            Some(f)
-        } else if let Some(u) = self.as_u128() {
-            Some(u as f64)
-        } else if let Some(i) = self.as_i128() {
-            Some(i as f64)
-        } else {
-            None
-        }
-    }
     /// returns true if the current value can be cast into a f64
     #[inline]
     #[must_use]
     fn is_f64_castable(&self) -> bool {
         self.cast_f64().is_some()
-    }
-
-    /// Tries to represent the value as a f32
-    #[allow(clippy::cast_possible_truncation)]
-    #[inline]
-    #[must_use]
-    fn as_f32(&self) -> Option<f32> {
-        self.as_f64().and_then(|u| {
-            if u <= f64::from(std::f32::MAX) && u >= f64::from(std::f32::MIN) {
-                // Since we check above
-                Some(u as f32)
-            } else {
-                None
-            }
-        })
     }
 
     /// returns true if the current value can be represented as a f64
@@ -599,42 +671,12 @@ pub trait Value:
         self.as_f32().is_some()
     }
 
-    /// Tries to get an element of an object as a f32
-    #[inline]
-    #[must_use]
-    fn get_f32<Q: ?Sized>(&self, k: &Q) -> Option<f32>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_f32)
-    }
-
-    /// Tries to represent the value as a &str
-    #[must_use]
-    fn as_str(&self) -> Option<&str>;
     /// returns true if the current value can be represented as a str
-
     #[inline]
     #[must_use]
     fn is_str(&self) -> bool {
         self.as_str().is_some()
     }
-
-    /// Tries to get an element of an object as a str
-    #[inline]
-    #[must_use]
-    fn get_str<Q: ?Sized>(&self, k: &Q) -> Option<&str>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_str)
-    }
-
-    /// Tries to represent the value as an array and returns a refference to it
-    #[must_use]
-    fn as_array(&self) -> Option<&Self::Array>;
 
     /// returns true if the current value can be represented as an array
     #[inline]
@@ -643,37 +685,11 @@ pub trait Value:
         self.as_array().is_some()
     }
 
-    /// Tries to get an element of an object as a array
-    #[inline]
-    #[must_use]
-    fn get_array<Q: ?Sized>(&self, k: &Q) -> Option<&Self::Array>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_array)
-    }
-
-    /// Tries to represent the value as an object and returns a refference to it
-    #[must_use]
-    fn as_object(&self) -> Option<&Self::Object>;
-
     /// returns true if the current value can be represented as an object
     #[inline]
     #[must_use]
     fn is_object(&self) -> bool {
         self.as_object().is_some()
-    }
-
-    /// Tries to get an element of an object as a object
-    #[inline]
-    #[must_use]
-    fn get_object<Q: ?Sized>(&self, k: &Q) -> Option<&Self::Object>
-    where
-        Self::Key: Borrow<Q> + Hash + Eq,
-        Q: Hash + Eq + Ord,
-    {
-        self.get(k).and_then(Value::as_object)
     }
 
     #[cfg(feature = "custom-types")]
@@ -693,11 +709,11 @@ pub trait Mutable: IndexMut<usize> + Value + Sized {
     ///
     /// Will return `Err` if `self` is not an object.
     #[inline]
-    fn insert<K, V>(&mut self, k: K, v: V) -> std::result::Result<Option<Self>, AccessError>
+    fn insert<K, V>(&mut self, k: K, v: V) -> std::result::Result<Option<Self::Target>, AccessError>
     where
-        K: Into<<Self as Value>::Key>,
-        V: Into<Self>,
-        <Self as Value>::Key: Hash + Eq,
+        K: Into<<Self as ValueAccess>::Key>,
+        V: Into<<Self as ValueAccess>::Target>,
+        <Self as ValueAccess>::Key: Hash + Eq,
     {
         self.as_object_mut()
             .ok_or(AccessError::NotAnObject)
@@ -712,9 +728,9 @@ pub trait Mutable: IndexMut<usize> + Value + Sized {
     ///
     /// Will return `Err` if `self` is not an Object.
     #[inline]
-    fn remove<Q: ?Sized>(&mut self, k: &Q) -> std::result::Result<Option<Self>, AccessError>
+    fn remove<Q: ?Sized>(&mut self, k: &Q) -> std::result::Result<Option<Self::Target>, AccessError>
     where
-        <Self as Value>::Key: Borrow<Q> + Hash + Eq,
+        <Self as ValueAccess>::Key: Borrow<Q> + Hash + Eq,
         Q: Hash + Eq + Ord,
     {
         self.as_object_mut()
@@ -732,7 +748,7 @@ pub trait Mutable: IndexMut<usize> + Value + Sized {
     #[inline]
     fn push<V>(&mut self, v: V) -> std::result::Result<(), AccessError>
     where
-        V: Into<Self>,
+        V: Into<<Self as ValueAccess>::Target>,
     {
         self.as_array_mut()
             .ok_or(AccessError::NotAnArray)
@@ -747,16 +763,16 @@ pub trait Mutable: IndexMut<usize> + Value + Sized {
     ///
     /// Will return `Err` if `self` is not an array.
     #[inline]
-    fn pop(&mut self) -> std::result::Result<Option<Self>, AccessError> {
+    fn pop(&mut self) -> std::result::Result<Option<Self::Target>, AccessError> {
         self.as_array_mut()
             .ok_or(AccessError::NotAnArray)
             .map(Array::pop)
     }
     /// Same as `get` but returns a mutable ref instead
     //    fn get_amut(&mut self, k: &str) -> Option<&mut Self>;
-    fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut Self>
+    fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut Self::Target>
     where
-        <Self as Value>::Key: Borrow<Q> + Hash + Eq,
+        <Self as ValueAccess>::Key: Borrow<Q> + Hash + Eq,
         Q: Hash + Eq + Ord,
     {
         self.as_object_mut().and_then(|m| m.get_mut(&k))
@@ -764,11 +780,11 @@ pub trait Mutable: IndexMut<usize> + Value + Sized {
 
     /// Same as `get_idx` but returns a mutable ref instead
     #[inline]
-    fn get_idx_mut(&mut self, i: usize) -> Option<&mut Self> {
+    fn get_idx_mut(&mut self, i: usize) -> Option<&mut Self::Target> {
         self.as_array_mut().and_then(|a| a.get_mut(i))
     }
     /// Tries to represent the value as an array and returns a mutable refference to it
-    fn as_array_mut(&mut self) -> Option<&mut <Self as Value>::Array>;
+    fn as_array_mut(&mut self) -> Option<&mut <Self as ValueAccess>::Array>;
     /// Tries to represent the value as an object and returns a mutable refference to it
     fn as_object_mut(&mut self) -> Option<&mut Self::Object>;
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -99,73 +99,6 @@ impl Value for StaticNode {
     fn is_null(&self) -> bool {
         self == &Self::Null
     }
-
-    #[cfg(feature = "128bit")]
-    #[inline]
-    #[must_use]
-    fn as_i64(&self) -> Option<i64> {
-        match self {
-            Self::I64(i) => Some(*i),
-            Self::U64(i) => i64::try_from(*i).ok(),
-            Self::I128(i) => i64::try_from(*i).ok(),
-            Self::U128(i) => i64::try_from(*i).ok(),
-            _ => None,
-        }
-    }
-
-    #[cfg(feature = "128bit")]
-    #[inline]
-    #[must_use]
-    fn as_i128(&self) -> Option<i128> {
-        match self {
-            Self::I128(i) => Some(*i),
-            Self::U128(i) => i128::try_from(*i).ok(),
-            Self::I64(i) => Some(i128::from(*i)),
-            Self::U64(i) => i128::try_from(*i).ok(),
-            _ => None,
-        }
-    }
-
-    #[cfg(feature = "128bit")]
-    #[inline]
-    #[must_use]
-    #[allow(clippy::cast_sign_loss)]
-    fn as_u64(&self) -> Option<u64> {
-        match self {
-            Self::I64(i) => u64::try_from(*i).ok(),
-            Self::U64(i) => Some(*i),
-            Self::I128(i) => u64::try_from(*i).ok(),
-            Self::U128(i) => u64::try_from(*i).ok(),
-            _ => None,
-        }
-    }
-    #[cfg(feature = "128bit")]
-    #[inline]
-    #[must_use]
-    #[allow(clippy::cast_sign_loss)]
-    fn as_u128(&self) -> Option<u128> {
-        match self {
-            Self::U128(i) => Some(*i),
-            Self::I128(i) => u128::try_from(*i).ok(),
-            Self::I64(i) => u128::try_from(*i).ok(),
-            Self::U64(i) => Some(u128::from(*i)),
-            _ => None,
-        }
-    }
-
-    #[cfg(feature = "128bit")]
-    #[inline]
-    #[allow(clippy::cast_precision_loss)]
-    fn cast_f64(&self) -> Option<f64> {
-        match self {
-            Self::F64(i) => Some(*i),
-            Self::I64(i) => Some(*i as f64),
-            Self::U64(i) => Some(*i as f64),
-            Self::I128(i) => Some(*i as f64),
-            Self::U128(i) => Some(*i as f64),
-            _ => None,
-        }
-    }
 }
 
 impl ValueAccess for StaticNode {
@@ -183,21 +116,6 @@ impl ValueAccess for StaticNode {
     #[must_use]
     fn as_object(&self) -> Option<&HashMap<Self::Key, Self>> {
         None
-    }
-
-    #[cfg(feature = "128bit")]
-    #[inline]
-    #[must_use]
-    fn value_type(&self) -> ValueType {
-        match self {
-            Self::Null => ValueType::Null,
-            Self::Bool(_) => ValueType::Bool,
-            Self::F64(_) => ValueType::F64,
-            Self::I128(_) => ValueType::I128,
-            Self::I64(_) => ValueType::I64,
-            Self::U128(_) => ValueType::U128,
-            Self::U64(_) => ValueType::U64,
-        }
     }
 
     #[inline]
@@ -320,6 +238,7 @@ impl ValueAccess for StaticNode {
             _ => None,
         }
     }
+
     #[inline]
     #[must_use]
     fn as_str(&self) -> Option<&str> {

--- a/src/node/cmp.rs
+++ b/src/node/cmp.rs
@@ -1,5 +1,5 @@
 use super::StaticNode;
-use crate::Value as ValueTrait;
+use crate::{Value as ValueTrait, ValueAccess};
 
 impl PartialEq<()> for StaticNode {
     #[inline]

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,0 +1,78 @@
+use crate::ValueAccess;
+
+impl<V> ValueAccess for Option<V>
+where
+    V: ValueAccess,
+{
+    type Target = V::Target;
+    type Key = V::Key;
+    type Array = V::Array;
+
+    type Object = V::Object;
+
+    fn as_bool(&self) -> Option<bool> {
+        self.as_ref().and_then(|v| v.as_bool())
+    }
+
+    fn as_i64(&self) -> Option<i64> {
+        self.as_ref().and_then(|v| v.as_i64())
+    }
+
+    fn as_u64(&self) -> Option<u64> {
+        self.as_ref().and_then(|v| v.as_u64())
+    }
+
+    fn as_f64(&self) -> Option<f64> {
+        self.as_ref().and_then(|v| v.as_f64())
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        self.as_ref().and_then(|v| v.as_str())
+    }
+
+    fn as_array(&self) -> Option<&Self::Array> {
+        self.as_ref().and_then(|v| v.as_array())
+    }
+
+    fn as_object(&self) -> Option<&Self::Object> {
+        self.as_ref().and_then(|v| v.as_object())
+    }
+}
+
+impl<V, E> ValueAccess for Result<V, E>
+where
+    V: ValueAccess,
+{
+    type Target = V::Target;
+    type Key = V::Key;
+    type Array = V::Array;
+    type Object = V::Object;
+
+    fn as_bool(&self) -> Option<bool> {
+        self.as_ref().ok().and_then(|v| v.as_bool())
+    }
+
+    fn as_i64(&self) -> Option<i64> {
+        self.as_ref().ok().and_then(|v| v.as_i64())
+    }
+
+    fn as_u64(&self) -> Option<u64> {
+        self.as_ref().ok().and_then(|v| v.as_u64())
+    }
+
+    fn as_f64(&self) -> Option<f64> {
+        self.as_ref().ok().and_then(|v| v.as_f64())
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        self.as_ref().ok().and_then(|v| v.as_str())
+    }
+
+    fn as_array(&self) -> Option<&Self::Array> {
+        self.as_ref().ok().and_then(|v| v.as_array())
+    }
+
+    fn as_object(&self) -> Option<&Self::Object> {
+        self.as_ref().ok().and_then(|v| v.as_object())
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,4 @@
+pub use crate::array::Array;
+pub use crate::generator::BaseGenerator;
+pub use crate::object::Object;
+pub use crate::{Builder, Mutable, Value, ValueAccess, Writable};


### PR DESCRIPTION
Extract the ValueAccess so `get_` and `as_` are now separated from the other trait requirements