### PR TITLE
Update abi_stable after upstreamed changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ ryu = "1"
 halfbrown = "0.1"
 float-cmp = "0.9"
 
-# FIXME: Temporary until the canges are upstreamed:
-# https://github.com/rodrimati1992/abi_stable_crates/pull/61
-abi_stable = { version = "0.10", optional = true, git = "https://github.com/marioortizmanero/abi_stable_crates.git", branch = "floating-point", default-features = false }
+abi_stable = { version = "0.10.3", optional = true, default-features = false }
 
 [features]
 # Support for 128 bit integers


### PR DESCRIPTION
The floating point numbers have been upstreamed with a workaround in the end. This simply updates the dependency to not use my git fork.