### PR TITLE
Temporary fix to enable compilation against ARM 32 bits

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -744,3 +744,12 @@ where
     *string = &string[idx..];
     Ok(())
 }
+
+#[cfg(target_arch = "arm")]
+#[inline(always)]
+pub(crate) unsafe fn write_str_simd<W>(_writer: &mut W, _string: &mut &[u8]) -> io::Result<()>
+where
+    W: std::io::Write,
+{
+    todo!("write_str_simd  not implemented for ARM 32 bits")
+}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -751,5 +751,5 @@ pub(crate) unsafe fn write_str_simd<W>(_writer: &mut W, _string: &mut &[u8]) -> 
 where
     W: std::io::Write,
 {
-    todo!("write_str_simd  not implemented for ARM 32 bits")
+    todo!("write_str_simd not implemented for ARM 32 bits")
 }


### PR DESCRIPTION
May fix https://github.com/simd-lite/value-trait/issues/26

Tested with [cross](https://github.com/cross-rs/cross):

```
$ cross build -v --release --target=arm-unknown-linux-gnueabihf
$ cross build -v --release --target=armv7-unknown-linux-gnueabihf
```