### PR TITLE
Fix buildability on unsupported CPU architectures

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -221,7 +221,10 @@ pub trait BaseGenerator {
     }
 
     #[cfg(not(any(
-        feature = "runtime-detection",
+        all(
+            feature = "runtime-detection",
+            any(target_arch = "x86_64", target_arch = "x86")
+        ),
         feature = "portable",
         target_feature = "avx2",
         target_feature = "sse4.2",


### PR DESCRIPTION
This pull request fixes the buildability on unsupported CPU architectures due to improper feature gating on the `write_str_simd` function.