### PR TITLE
Implement optional serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ halfbrown = { version = "0.2", optional = true }
 float-cmp = "0.9"
 hashbrown = { version = "0.14", optional = true }
 abi_stable = { version = "0.11.0", optional = true, default-features = false }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 default = ["custom-types", "halfbrown", "runtime-detection"]
@@ -35,3 +36,10 @@ runtime-detection = []
 
 # portable simd support (as of rust 1.73 nightly only)
 portable = []
+
+# include serde Serialize/Deserialize implementation for public enums
+serde = [ "dep:serde" ]
+
+[dev-dependencies]
+value-trait = { path = ".", features = ["serde", "runtime-detection", "custom-types", "128bit"] }
+serde_test = { version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ impl std::error::Error for AccessError {}
 
 /// Extended types that have no native representation in JSON
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExtendedValueType {
     /// A 32 bit signed integer value
     I32,
@@ -118,6 +119,7 @@ impl fmt::Display for ExtendedValueType {
 
 /// Types of JSON values
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ValueType {
     /// null
     Null,

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,6 +12,7 @@ mod from;
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "c-abi", repr(C))]
 #[cfg_attr(feature = "c-abi", derive(abi_stable::StableAbi))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StaticNode {
     /// A signed 64 bit integer.
     I64(i64),
@@ -311,5 +312,60 @@ impl Default for StaticNode {
     #[must_use]
     fn default() -> Self {
         Self::Null
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_test::{assert_tokens, Token};
+    #[test]
+    fn static_node_serde() {
+        let test_i64 = StaticNode::I64(-5);
+        let test_u64 = StaticNode::U64(5);
+        let test_f64 = StaticNode::F64(5.4);
+        let test_bool = StaticNode::Bool(true);
+        let test_null = StaticNode::Null;
+
+        assert_tokens(
+            &test_i64,
+            &[
+                Token::Enum { name: "StaticNode" },
+                Token::Str("I64"),
+                Token::I64(-5),
+            ],
+        );
+        assert_tokens(
+            &test_u64,
+            &[
+                Token::Enum { name: "StaticNode" },
+                Token::Str("U64"),
+                Token::U64(5),
+            ],
+        );
+        assert_tokens(
+            &test_f64,
+            &[
+                Token::Enum { name: "StaticNode" },
+                Token::Str("F64"),
+                Token::F64(5.4),
+            ],
+        );
+        assert_tokens(
+            &test_bool,
+            &[
+                Token::Enum { name: "StaticNode" },
+                Token::Str("Bool"),
+                Token::Bool(true),
+            ],
+        );
+        assert_tokens(
+            &test_null,
+            &[
+                Token::Enum { name: "StaticNode" },
+                Token::Str("Null"),
+                Token::Unit,
+            ],
+        );
     }
 }


### PR DESCRIPTION
This is part of a larger effort to try and find a way to introspect serde_json Deserializer Tapes before actually deserializing. Since it's not actually possible to get at the tape in a serde::Deserialize::deserialize function, the next best thing is (possibly) to recreate the tape from the deserializer using standard deserialization - a kind of pass-thru. This will surely not perform TOO well, but it's really no different from serde_json's own RawValue deserialization. Anyway, in make Node deserializable in in simd_json, we need to, be able to deserialize StaticNode from here - hence the PR.