### PR TITLE
Implement feature "ordered-float"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ itoa = "1"
 ryu = "1"
 halfbrown = { version = "0.2", optional = true }
 float-cmp = "0.9"
+ordered-float = { version = "4", optional = true }
 hashbrown = { version = "0.14", optional = true }
 abi_stable = { version = "0.11.0", optional = true, default-features = false }
 
@@ -32,6 +33,9 @@ c-abi = ["abi_stable"]
 
 # use runtime detection of the CPU features where possible instead of enforcing an instruction set
 runtime-detection = []
+
+# wrap floats in ordered-float - allowing them to be Eq
+ordered-float = ["dep:ordered-float"]
 
 # portable simd support (as of rust 1.73 nightly only)
 portable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ default = ["custom-types", "halfbrown", "runtime-detection"]
 # Support for custom types
 custom-types = []
 
-# Support for abi-stable's `StableAbi` implementation
+# Support for abi-stable's `StableAbi` implementation - INCOMPATIBLE WITH ordered-float
 c-abi = ["abi_stable"]
 
 # use runtime detection of the CPU features where possible instead of enforcing an instruction set
 runtime-detection = []
 
-# wrap floats in ordered-float - allowing them to be Eq
+# wrap floats in ordered-float - allowing them to be Eq - INCOMPATIBLE WITH c-abi
 ordered-float = ["dep:ordered-float"]
 
 # portable simd support (as of rust 1.73 nightly only)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ compile_error!(
     the `128bit` feature, and that they have been merged by Cargo."
 );
 
+#[cfg(all(feature = "c-abi", feature = "ordered-float"))]
+compile_error!("Combining the features `c-abi` and `ordered-float` is impossible because ordered_float::OrderedFloat does not implement `StableAbi`");
+
 use std::borrow::Cow;
 use std::fmt;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -32,7 +32,7 @@ pub enum StaticNode {
     #[cfg(not(feature = "ordered-float"))]
     F64(f64),
     #[cfg(feature = "ordered-float")]
-    /// A floating point value, as an OrderedFloat (not allow for Eq)
+    /// A floating point value, as an `OrderedFloat` (not allow for Eq)
     F64(OrderedFloat<f64>),
     /// A boolean value
     Bool(bool),

--- a/src/node.rs
+++ b/src/node.rs
@@ -200,10 +200,7 @@ impl ValueAsScalar for StaticNode {
     #[must_use]
     fn as_f64(&self) -> Option<f64> {
         match self {
-            #[cfg(not(feature = "ordered-float"))]
-            Self::F64(i) => Some(*i),
-            #[cfg(feature = "ordered-float")]
-            Self::F64(i) => Some(i.0),
+            Self::F64(i) => Some((*i).into()),
             _ => None,
         }
     }
@@ -214,10 +211,7 @@ impl ValueAsScalar for StaticNode {
     #[allow(clippy::cast_precision_loss)]
     fn cast_f64(&self) -> Option<f64> {
         match self {
-            #[cfg(not(feature = "ordered-float"))]
-            Self::F64(i) => Some(*i),
-            #[cfg(feature = "ordered-float")]
-            Self::F64(i) => Some(i.0),
+            Self::F64(i) => Some((*i).into()),
             Self::I64(i) => Some(*i as f64),
             Self::U64(i) => Some(*i as f64),
             _ => None,
@@ -229,10 +223,7 @@ impl ValueAsScalar for StaticNode {
     #[allow(clippy::cast_precision_loss)]
     fn cast_f64(&self) -> Option<f64> {
         match self {
-            #[cfg(not(feature = "ordered-float"))]
-            Self::F64(i) => Some(*i),
-            #[cfg(feature = "ordered-float")]
-            Self::F64(i) => Some(i.0),
+            Self::F64(i) => Some((*i).into()),
             Self::I64(i) => Some(*i as f64),
             Self::U64(i) => Some(*i as f64),
             Self::I128(i) => Some(*i as f64),
@@ -310,7 +301,10 @@ impl PartialEq for StaticNode {
         match (self, other) {
             (Self::Null, Self::Null) => true,
             (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
+            #[cfg(not(feature = "ordered-float"))]
             (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
+            #[cfg(feature = "ordered-float")]
+            (Self::F64(v1), Self::F64(v2)) => v1.eq(v2),
             (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
             (Self::U128(v1), Self::U128(v2)) => v1.eq(v2),
             (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,8 +15,10 @@ mod from;
 
 /// Static tape node
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "ordered-float", derive(Eq))]
 #[cfg_attr(feature = "c-abi", repr(C))]
 #[cfg_attr(feature = "c-abi", derive(abi_stable::StableAbi))]
+
 pub enum StaticNode {
     /// A signed 64 bit integer.
     I64(i64),
@@ -200,6 +202,7 @@ impl ValueAsScalar for StaticNode {
     #[must_use]
     fn as_f64(&self) -> Option<f64> {
         match self {
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Self::F64(i) => Some((*i).into()),
             _ => None,
         }
@@ -211,6 +214,7 @@ impl ValueAsScalar for StaticNode {
     #[allow(clippy::cast_precision_loss)]
     fn cast_f64(&self) -> Option<f64> {
         match self {
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Self::F64(i) => Some((*i).into()),
             Self::I64(i) => Some(*i as f64),
             Self::U64(i) => Some(*i as f64),
@@ -269,9 +273,6 @@ impl fmt::Display for StaticNode {
         }
     }
 }
-
-#[cfg(feature = "ordered-float")]
-impl Eq for StaticNode {}
 
 #[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
 impl PartialEq for StaticNode {

--- a/src/node/cmp.rs
+++ b/src/node/cmp.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "ordered-float")]
+use ordered_float::OrderedFloat;
+
 use crate::{base::ValueAsScalar, derived::TypedScalarValue};
 
 use super::StaticNode;

--- a/src/node/cmp.rs
+++ b/src/node/cmp.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "ordered-float")]
-use ordered_float::OrderedFloat;
-
 use crate::{base::ValueAsScalar, derived::TypedScalarValue};
 
 use super::StaticNode;

--- a/src/node/from.rs
+++ b/src/node/from.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "ordered-float")]
 use ordered_float::OrderedFloat;
 
 use crate::StaticNode;

--- a/src/node/from.rs
+++ b/src/node/from.rs
@@ -1,3 +1,5 @@
+use ordered_float::OrderedFloat;
+
 use crate::StaticNode;
 
 /********* atoms **********/
@@ -109,7 +111,9 @@ impl From<usize> for StaticNode {
     }
 }
 
+
 /********* f_ **********/
+#[cfg(not(feature = "ordered-float"))]
 impl From<f32> for StaticNode {
     #[inline]
     #[must_use]
@@ -118,10 +122,29 @@ impl From<f32> for StaticNode {
     }
 }
 
+#[cfg(not(feature = "ordered-float"))]
 impl From<f64> for StaticNode {
     #[inline]
     #[must_use]
     fn from(f: f64) -> Self {
         Self::F64(f)
+    }
+}
+
+#[cfg(feature = "ordered-float")]
+impl From<f32> for StaticNode {
+    #[inline]
+    #[must_use]
+    fn from(f: f32) -> Self {
+        Self::F64(OrderedFloat::from(f as f64))
+    }
+}
+
+#[cfg(feature = "ordered-float")]
+impl From<f64> for StaticNode {
+    #[inline]
+    #[must_use]
+    fn from(f: f64) -> Self {
+        Self::F64(OrderedFloat::from(f))
     }
 }

--- a/src/node/from.rs
+++ b/src/node/from.rs
@@ -112,7 +112,6 @@ impl From<usize> for StaticNode {
     }
 }
 
-
 /********* f_ **********/
 #[cfg(not(feature = "ordered-float"))]
 impl From<f32> for StaticNode {
@@ -137,7 +136,7 @@ impl From<f32> for StaticNode {
     #[inline]
     #[must_use]
     fn from(f: f32) -> Self {
-        Self::F64(OrderedFloat::from(f as f64))
+        Self::F64(OrderedFloat::from(f64::from(f)))
     }
 }
 


### PR DESCRIPTION
If we wrap a float in OrderedFloat then we can claim "Eq" - and THEN we can be compatible with serde_json.

The feature is incompatible with `c-abi` due to OrderedFloat not implementing StableAbi