### PR TITLE
fix: string fallback consumption

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -236,9 +236,7 @@ pub trait BaseGenerator {
     /// # Errors
     ///  if the write fails
     unsafe fn write_str_simd(&mut self, string: &mut &[u8]) -> io::Result<()> {
-        write_string_rust(self.get_writer(), string)?;
-        *string = &string[string.len()..];
-        Ok(())
+        write_str_simd_rust(self.get_writer(), string)
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -420,11 +418,21 @@ where
         write_str_simd_sse42(writer, string)
     } else {
         #[cfg(not(feature = "portable"))]
-        return write_string_rust(writer, string);
+        return write_str_simd_rust(writer, string);
         #[cfg(feature = "portable")]
         return write_str_simd_portable(writer, string);
     }
 }
+#[inline]
+fn write_str_simd_rust<W>(writer: &mut W, string: &mut &[u8]) -> io::Result<()>
+where
+    W: Write,
+{
+    write_string_rust(writer, string)?;
+    *string = &string[string.len()..];
+    Ok(())
+}
+
 #[inline]
 fn write_string_container<W>(writer: &mut W, string: &[u8], mut start: usize) -> io::Result<()>
 where
@@ -893,5 +901,14 @@ mod tests {
         let mut string = "Hello, \"World!\"".as_bytes();
         super::write_string_rust(&mut writer, &mut string).expect("failed to write string");
         assert_eq!(writer, "Hello, \\\"World!\\\"".as_bytes());
+    }
+    #[test]
+    fn test_write_str_simd_rust_consumes_string() {
+        let mut writer = Vec::new();
+        let mut string = "Hello, \"World!\"".as_bytes();
+        super::write_str_simd_rust(&mut writer, &mut string).expect("failed to write string");
+        super::write_string_rust(&mut writer, &mut string).expect("failed to write string");
+        assert_eq!(writer, "Hello, \\\"World!\\\"".as_bytes());
+        assert!(string.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Fix the x86 runtime-detection fallback path for string serialization when neither AVX2 nor SSE4.2 is available.

In that fallback path, `write_string_rust` writes the full remaining string but does not advance the `&mut &[u8]` input slice. The outer `write_string_content` then treats the same slice as still remaining and writes it again.

## Related
https://github.com/web-infra-dev/rspack/issues/14701

## Example

On CPUs without AVX2/SSE4.2, serializing:

```rust
simd_json::to_string("hello")
```

could produce:

```text
"hellohello"
```

instead of:

```text
"hello"
```

This patch routes the fallback through a helper that writes via the Rust implementation and then consumes the slice, matching the contract used by the SIMD paths.

## Tests
- `cargo test test_write_str_simd_rust_consumes_string`
- verified with qemu emulation https://github.com/intellild/simd-json-playground `verify-qemu.sh`
